### PR TITLE
Update NELM version to 1.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 FROM alpine:3 AS downloader
 
-ARG NELM_VERSION=1.12.1
+ARG NELM_VERSION=1.12.2
 ARG TARGETARCH
 
 WORKDIR /tmp


### PR DESCRIPTION
This PR updates the NELM version from 1.12.1 to 1.12.2.

Automated update triggered by a new NELM release.